### PR TITLE
package.js

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -2,6 +2,7 @@ The MIT License (MIT)
 
 Copyright (c) 2014 Jess Latimer
 Copyright (c) 2015 AppShore Inc
+Copyright (c) 2016 Eric Smyth
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -18,16 +18,23 @@ $ meteor add appshore:recaptcha
 
 ###On The Client
 
-Add your reCAPTCHA public key (from Google) to the package. Do this in client-side code.
+Add your reCAPTCHA public key (from Google) to the package. Do this in client-side code. Config values listed below are package defaults
 
 ``` javascript
 Meteor.startup(function() {
     reCAPTCHA.config({
-        theme: 'light'  // 'light' default or 'dark'
-        publickey: 'your_public_key_from_google'
+        sitekey: 'your_public_site_key_from_google', //REQUIRED
+        theme: 'light', //OPTIONAL. <light|dark> Specifies the color theme of the widget
+        type: 'image', //OPTIONAL. <audio|image> Specifies the type of captcha to serve
+        size: 'normal', //OPTIONAL. <normal|compact> Specifies the type of captcha to serve
+        callback: function(val) {}, //OPTIONAL. The name of your callback function to be executed when the user submits a successful CAPTCHA response. The user's response, g-recaptcha-response, will be the input for your callback function.
+        tabindex: 0, //OPTIONAL. The tabindex of the widget and challenge. If other elements in your page use tabindex, it should be set to make user navigation easier.
+        "expired-callback": function() {} //OPTIONAL. The name of your callback function to be executed when the recaptcha response expires and the user needs to solve a new CAPTCHA.
     });
 });
 ```
+
+[Official documentation](https://developers.google.com/recaptcha/docs/display#render_param)
 
 ###On The Server
 

--- a/client/client.js
+++ b/client/client.js
@@ -1,26 +1,24 @@
 reCAPTCHA = {
     settings: {
+        theme: "light",
+        type: "image",
+        size: "normal",
+        tabindex: 0
     },
 
     config: function(settings) {
         return _.extend(this.settings, settings);
-    },
+    }
 };
 
 
 window.onloadcaptcha = function() {
-    $('[name=reCaptcha]').each( function(index){
+    $('[name=reCaptcha]').each(function(){
         $(this).empty();
-        grecaptcha.render(this.id, {
-                sitekey: reCAPTCHA.settings.publickey,
-                theme: reCAPTCHA.settings.theme,
-                callback: function () {
-                return;
-            }
-        });
+        grecaptcha.render(this.id, reCAPTCHA.settings);
     });
 };
 
 Template.reCAPTCHA.rendered = function() {
-    $.getScript('//www.google.com/recaptcha/api.js?onload=onloadcaptcha&render=explicit');
+    $.getScript('https://www.google.com/recaptcha/api.js?onload=onloadcaptcha&render=explicit');
 };

--- a/package.js
+++ b/package.js
@@ -2,7 +2,7 @@ Package.describe({
     name: "appshore:recaptcha",
     summary: "Implementation of Google reCAPTCHA V2 for Meteor",
     git: "https://github.com/appshore/Meteor-reCAPTCHA.git",
-    version: "2.0.6",
+    version: "2.1.0",
     license: "MIT"
 });
 
@@ -12,10 +12,10 @@ Package.onUse(function(api) {
 
     api.use([
         'templating',
-        'handlebars',
+        'handlebars'
     ], 'client');
     api.use([
-        'http',
+        'http'
     ], 'server');
 
     api.addFiles(['server/server.js'], 'server');


### PR DESCRIPTION
Modified the client.js to pass the settings object to render, rather than creating a new object. This means that all Google reCAPTCHA settings are supported (e.g., callback, type) and the code won't need to be updated in the future to support additional options, if Google adds any. Added some default settings (they mirror the current Google defaults) and notes to the README.md about all currently supported settings.
